### PR TITLE
fix: correct Sunlu Midnight Blue Masterspool labels

### DIFF
--- a/data/container_spool/spools_filament.json
+++ b/data/container_spool/spools_filament.json
@@ -381,7 +381,7 @@
     "id": "sunlu_midnight_blue_v1",
     "brandId": 51857,
     "brand": "Sunlu",
-    "label": "Midnight Blue V1",
+    "label": "Midnight Blue V2",
     "type": "Masterspool",
     "container_weight": 165,
     "img": "../assets/img/spool_filament/sunlu_midnight_blueV1.png"
@@ -390,7 +390,7 @@
     "id": "sunlu_midnight_blue_v2",
     "brandId": 51857,
     "brand": "Sunlu",
-    "label": "Midnight Blue V2",
+    "label": "Midnight Blue V3",
     "type": "Masterspool",
     "container_weight": 219,
     "img": "../assets/img/spool_filament/sunlu_midnight_blueV2.png"


### PR DESCRIPTION
sunlu_midnight_blue_v1 was mislabeled "Midnight Blue V1" (actually V2) and sunlu_midnight_blue_v2 was mislabeled "Midnight Blue V2" (actually V3). Only the label strings change — id, type, container_weight and img stay untouched, so existing per-account containerOverrides and any spool's stored container_id keep resolving to the same entries.